### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/rules-engine/security/code-scanning/1](https://github.com/conorheffron/rules-engine/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block to the workflow at the top level, applying least privilege settings to all jobs. For this workflow, which checks out the repository and builds it, the required permission is `contents: read`. You should insert the `permissions` block directly beneath the `name:` field (after line 9, before `on:`), or at the job level if only a particular job needs restriction. Since the workflow contains just a single job and no required write actions, the minimal fix is to add:

```yaml
permissions:
  contents: read
```

Add this block after line 9. No further imports, definitions, or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
